### PR TITLE
POST: create new direct upload connection

### DIFF
--- a/app/api/connections/route.ts
+++ b/app/api/connections/route.ts
@@ -3,8 +3,6 @@ import { tryAndCatch } from "@/lib/try-catch";
 import { NextRequest, NextResponse } from "next/server";
 import { APIError } from "@/lib/APIError";
 import { databaseDrizzle } from "@/db";
-import { users } from "@/db/schemas/users";
-import { eq, sql } from "drizzle-orm";
 
 
 
@@ -17,21 +15,6 @@ export async function GET(request: NextRequest) {
         code: authError.code,
         message: authError.message,
       }, { status: authError.status })
-    }
-
-    const { error: updateApiCallsError } = await tryAndCatch(databaseDrizzle
-      .update(users)
-      .set({ apiCalls: sql`${users.apiCalls} + 1` })
-      .where(eq(users.id, userId)))
-
-    if (updateApiCallsError) {
-      return NextResponse.json(
-        {
-          code: "forbidden",
-          message: "The requested resource was not found.",
-        },
-        { status: 403 },
-      )
     }
 
     const { data, error: queryError } = await tryAndCatch(databaseDrizzle.query.connections.findMany({
@@ -80,7 +63,6 @@ export async function GET(request: NextRequest) {
       files: conn.files,
     }))
 
-
     return NextResponse.json(response, { status: 200 });
   } catch (error: any) {
     return NextResponse.json(
@@ -88,5 +70,4 @@ export async function GET(request: NextRequest) {
       { status: 500 },
     );
   }
-
 }

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,0 +1,70 @@
+import { setDirectUploadConnection } from "@/DataSource/DirectUpload/setDirectUploadConnection";
+import { directProcessFiles } from "@/fileProcessors";
+import { checkAuth } from "@/lib/api_key";
+import { tryAndCatch } from "@/lib/try-catch";
+import { addToProcessFilesQueue } from "@/workers/queues/jobs/processFiles.job";
+import { NextRequest, NextResponse } from "next/server";
+import { APIError } from "openai";
+
+export async function POST(request: NextRequest) {
+  const wait = request.nextUrl.searchParams.get("wait")
+
+  try {
+    const {
+      data: userId,
+      error: authError,
+    } = await tryAndCatch<string, APIError>(checkAuth(request))
+
+    if (authError) return NextResponse.json({
+      code: authError.code,
+      message: authError.message,
+    }, { status: authError.status })
+
+    const { data: formData, error: errorForm } = await tryAndCatch(request.formData());
+    if (errorForm) return NextResponse.json({
+      code: "bad_request",
+      message: errorForm.message,
+    }, { status: 400 })
+
+    formData.set("userId", userId)
+    const {
+      data: filesConfig,
+      error: errorConfig
+    } = await tryAndCatch(setDirectUploadConnection(formData))
+
+    if (errorConfig) return NextResponse.json({
+      code: "bad_request",
+      message: errorConfig.message,
+    }, { status: 400 })
+
+    if (wait === "true") {
+      const { error } = await tryAndCatch(directProcessFiles(filesConfig))
+      if (error) return NextResponse.json({
+        code: "internal_server_error",
+        message: error.message
+      }, { status: 500 });
+
+      return NextResponse.json({
+        code: "ok",
+        message: "Your file was successfully uploaded and processed.",
+      }, { status: 200 })
+    }
+
+    const { error: errorQueue } = await tryAndCatch(addToProcessFilesQueue(filesConfig))
+    if (errorQueue) return NextResponse.json({
+      code: "internal_server_error",
+      message: errorQueue.message,
+    }, { status: 500 })
+
+    return NextResponse.json({
+      code: "ok",
+      message: "Your file has been successfully uploaded and queued for processing.",
+    }, { status: 200 })
+
+  } catch (error: any) {
+    return NextResponse.json({
+      code: "internal_server_error",
+      message: error.message,
+    }, { status: 500 });
+  }
+}

--- a/components/Connections/Connections.tsx
+++ b/components/Connections/Connections.tsx
@@ -15,9 +15,11 @@ import {
 } from "@/components/ui/tooltip"
 
 export default function Connections({ connections, tokens }: { connections: ConnectionQuery[], tokens: ConnectionToken }) {
+  const [isMounted, setIsMounted] = useState(false)
   const [connProgress, setConnProgress] = useState<ConnectionProgress | null>(null);
 
   useEffect(() => {
+    setIsMounted(true)
     const eventSource = new EventSource("/api/progress")
     eventSource.onmessage = (event) => {
       const data = JSON.parse(event.data) as ConnectionProgress
@@ -51,10 +53,10 @@ export default function Connections({ connections, tokens }: { connections: Conn
       <TableCell>{progress?.processedFile || connection.files.reduce((sum, file) => sum + file.totalPages, 0)}</TableCell>
       <TableCell>{progress?.processedPage || connection.files.length}</TableCell>
       <TableCell>
-        {timeAgo(connection.createdAt)}
+        <span>{!isMounted ? "Loading..." : timeAgo(connection.createdAt)}</span>
       </TableCell>
       <TableCell>
-        <LastSync lastSync={progress?.lastAsync ?? connection.lastSynced} />
+        {!isMounted ? "Loading..." : <LastSync lastSync={progress?.lastAsync ?? connection.lastSynced} />}
       </TableCell>
       <TableCell>
         <ConnectionStatus status={progress?.status} />

--- a/db/schemas/connections.ts
+++ b/db/schemas/connections.ts
@@ -28,7 +28,7 @@ export const connections = pgTable("connection", {
     .references(() => users.id, { onDelete: "cascade" })
     .notNull(),
   service: connectionEnum("service").notNull(),
-  identifier: text("identifier").notNull(),
+  identifier: text("identifier").unique().notNull(),
   credentials: jsonb("credentials"),
   connectionMetadata: jsonb("connection_metadata"),
   folderName: text("folder_name").default("*"),

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1743627093450,
       "tag": "0005_tough_beyonder",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1744043197392,
+      "tag": "0006_large_bruce_banner",
+      "breakpoints": true
     }
   ]
 }

--- a/fileProcessors/index.ts
+++ b/fileProcessors/index.ts
@@ -4,7 +4,6 @@ import { RecursiveCharacterTextSplitter } from "@langchain/textsplitters";
 import { v4 as uuidv4 } from 'uuid';
 import { getTitleAndSummary, vectorizeText } from "@/openAi";
 import { qdrant_collection_name, qdrantCLient } from "@/qdrant";
-import { redisConnection } from "@/workers/redis";
 import { publishProgress } from "@/events";
 import { connections, processedFiles } from "@/db/schemas/connections";
 import { eq } from "drizzle-orm";
@@ -26,7 +25,6 @@ export type PageContent = {
 }
 
 export const directProcessFiles = async ({ files, metadata, service, connectionId, links, pageLimit, fileLimit }: TQueue) => {
-
   // Create promises for processing file URLs
   const filePromises = files.map(async (file) => {
     const content = await processPdfBuffer(Buffer.from(file.content, 'base64'));
@@ -165,9 +163,6 @@ const processFiles = async (filesContent: FileContent[], service: string, connec
           })
       )
 
-      allPoints.forEach(async point => {
-        await redisConnection.set(point.payload._hash, JSON.stringify(point.payload._metadata), "EX", 3600 * 5) // Cache for 5 hours
-      })
     }
     await databaseDrizzle
       .update(connections)
@@ -197,7 +192,7 @@ const processFiles = async (filesContent: FileContent[], service: string, connec
 const processingTextPage = async (pageText: string, pageIndex: number, baseMetadata: any, splitter: RecursiveCharacterTextSplitter) => {
   const chunks = await splitter.splitText(pageText)
   for (const [chunkIdx, chunk] of chunks.entries()) {
-    if(chunk.length === 0) continue;
+    if (chunk.length === 0) continue;
     const textHash = generateHash(chunk);
     const textMetadata = {
       ...baseMetadata,
@@ -208,61 +203,9 @@ const processingTextPage = async (pageText: string, pageIndex: number, baseMetad
       _hash: textHash,
     };
 
-    const cachedMetadata = await redisConnection.get(textHash)
-    if (!cachedMetadata || cachedMetadata !== JSON.stringify(baseMetadata._metadata)) {
-      const existingPoints = await qdrantCLient.scroll(qdrant_collection_name, {
-        filter: {
-          must: [{ key: "_hash", match: { value: textHash } }]
-        },
-        limit: 1,
-        with_payload: true,
-        with_vector: true,
-      });
-      if (existingPoints.points.length > 0) {
-        return {
-          id: existingPoints.points[0].id,
-          vector: existingPoints.points[0].vector as number[],
-          payload: {
-            ...existingPoints.points[0].payload,
-            _metadata: baseMetadata._metadata
-          }
-        }
-      }
-
-      const textVectors = await vectorizeText(chunk);
-      const { title, summary } = await getTitleAndSummary(chunk, JSON.stringify(textMetadata))
-      const metadata = {
-        ...textMetadata,
-        _title: title,
-        _summary: summary
-      }
-
-      return {
-        id: uuidv4(),
-        vector: textVectors,
-        payload: metadata,
-      };
-    }
-  }
-}
-
-const processingTablePage = async (tables: unknown[], pageIndex: number, baseMetadata: any) => {
-  const pageTables = tables.map(t => JSON.stringify(t)).join("\n-------------\n")
-
-  const tableHash = generateHash(pageTables);
-  const tableMetadata = {
-    ...baseMetadata,
-    _page_number: pageIndex + 1,
-    _type: "table",
-    _content: pageTables,
-    _hash: tableHash,
-  };
-
-  const cachedMetadata = await redisConnection.get(tableHash)
-  if (!cachedMetadata || cachedMetadata !== JSON.stringify(baseMetadata._metadata)) {
     const existingPoints = await qdrantCLient.scroll(qdrant_collection_name, {
       filter: {
-        must: [{ key: "_hash", match: { value: tableHash } }]
+        must: [{ key: "_hash", match: { value: textHash } }]
       },
       limit: 1,
       with_payload: true,
@@ -279,20 +222,66 @@ const processingTablePage = async (tables: unknown[], pageIndex: number, baseMet
       }
     }
 
-    const tableVectors = await vectorizeText(pageTables);
-    const { title, summary } = await getTitleAndSummary(pageTables, JSON.stringify(tableMetadata))
+    const textVectors = await vectorizeText(chunk);
+    const { title, summary } = await getTitleAndSummary(chunk, JSON.stringify(textMetadata))
     const metadata = {
-      ...tableMetadata,
+      ...textMetadata,
       _title: title,
       _summary: summary
     }
 
     return {
       id: uuidv4(),
-      vector: tableVectors,
+      vector: textVectors,
       payload: metadata,
     };
   }
+}
+
+const processingTablePage = async (tables: unknown[], pageIndex: number, baseMetadata: any) => {
+  const pageTables = tables.map(t => JSON.stringify(t)).join("\n-------------\n")
+
+  const tableHash = generateHash(pageTables);
+  const tableMetadata = {
+    ...baseMetadata,
+    _page_number: pageIndex + 1,
+    _type: "table",
+    _content: pageTables,
+    _hash: tableHash,
+  };
+
+  const existingPoints = await qdrantCLient.scroll(qdrant_collection_name, {
+    filter: {
+      must: [{ key: "_hash", match: { value: tableHash } }]
+    },
+    limit: 1,
+    with_payload: true,
+    with_vector: true,
+  });
+  if (existingPoints.points.length > 0) {
+    return {
+      id: existingPoints.points[0].id,
+      vector: existingPoints.points[0].vector as number[],
+      payload: {
+        ...existingPoints.points[0].payload,
+        _metadata: baseMetadata._metadata
+      }
+    }
+  }
+
+  const tableVectors = await vectorizeText(pageTables);
+  const { title, summary } = await getTitleAndSummary(pageTables, JSON.stringify(tableMetadata))
+  const metadata = {
+    ...tableMetadata,
+    _title: title,
+    _summary: summary
+  }
+
+  return {
+    id: uuidv4(),
+    vector: tableVectors,
+    payload: metadata,
+  };
 }
 
 function generateHash(content: string): string {

--- a/fileProcessors/index.ts
+++ b/fileProcessors/index.ts
@@ -197,6 +197,7 @@ const processFiles = async (filesContent: FileContent[], service: string, connec
 const processingTextPage = async (pageText: string, pageIndex: number, baseMetadata: any, splitter: RecursiveCharacterTextSplitter) => {
   const chunks = await splitter.splitText(pageText)
   for (const [chunkIdx, chunk] of chunks.entries()) {
+    if(chunk.length === 0) continue;
     const textHash = generateHash(chunk);
     const textMetadata = {
       ...baseMetadata,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

part: #29  <!-- reference the related issue e.g. #150 -->

### Description:
This PR introduces a new POST endpoint at `/api/upload` to enable users to create direct upload connections for file uploads, supporting both immediate and queued processing workflows.

- If `wait=true` (query parameter), : processes files immediately with directProcessFiles and returns a success message: **"Your file was successfully uploaded and processed."**
- If `wait=false` **(default)**, : queues files for later processing with addToProcessFilesQueue and returns: **"Your file has been successfully uploaded and queued for processing."**
```json
{
    "code": "ok",
    "message": "Your file has been successfully uploaded and queued for processing."
}
```

<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
