### PR TITLE
POST: Sync connection by connection_id and fix bugs and status api

### DIFF
--- a/DataSource/DirectUpload/UpdateConfigDirect/UpdateConfigDirect.tsx
+++ b/DataSource/DirectUpload/UpdateConfigDirect/UpdateConfigDirect.tsx
@@ -14,12 +14,12 @@ import {
   DialogDescription,
 } from '@/components/ui/dialog';
 
-export const UpdateConfigDirect = ({ connection, status }: { connection: ConnectionQuery, status: "PROCESSING" | "FINISHED" | undefined}) => {
+export const UpdateConfigDirect = ({ connection, status }: { connection: ConnectionQuery, status: "PROCESSING" | "FINISHED" | undefined }) => {
   const [open, setOpen] = useState(false)
 
   return (<Dialog open={open} onOpenChange={setOpen} >
     <DialogTrigger asChild>
-      <Button size='sm' variant={connection.isConfigSet ? 'ghost' : 'default'} disabled={status === 'PROCESSING' && connection.isSyncing} >
+      <Button size='sm' variant={connection.isConfigSet ? 'ghost' : 'default'} disabled={status === 'PROCESSING' || (!status && connection.isSyncing)}>
         <Settings2 />
         Configure
       </Button>

--- a/DataSource/GoogleDrive/ConfigGoogleDrive/ConfigGoogleDrive.tsx
+++ b/DataSource/GoogleDrive/ConfigGoogleDrive/ConfigGoogleDrive.tsx
@@ -22,11 +22,7 @@ import {
 
 import { setConnectionConfig } from '@/actions/connctions/new';
 
-export const ConfigGoogleDrive = ({ connection, token,status }: { 
-  connection: ConnectionQuery, 
-  token: string | null | undefined,
-  status: "PROCESSING" | "FINISHED" | undefined
-}) => {
+export const ConfigGoogleDrive = ({ connection, token, status }: { connection: ConnectionQuery, token: string | null | undefined, status: "PROCESSING" | "FINISHED" | undefined }) => {
   const [open, setOpen] = useState(false)
   const [isConfigSet, setIsConfigSet] = useState(connection.isConfigSet)
   const [openPicker] = useDrivePicker()
@@ -100,7 +96,7 @@ export const ConfigGoogleDrive = ({ connection, token,status }: {
 
   return (<Dialog open={open} onOpenChange={o => setOpen(o)} >
     <DialogTrigger asChild>
-      <Button size='sm' variant={isConfigSet ? 'ghost' : 'default'} disabled={status === 'PROCESSING' && connection.isSyncing} onClick={() => setOpen(true)} >
+      <Button size='sm' variant={isConfigSet ? 'ghost' : 'default'} disabled={status === 'PROCESSING' || (!status && connection.isSyncing)} onClick={() => setOpen(true)} >
         <Settings2 />
         Configure
       </Button>

--- a/DataSource/index.tsx
+++ b/DataSource/index.tsx
@@ -7,13 +7,12 @@ import { UpdateConfigDirect } from './DirectUpload/UpdateConfigDirect/UpdateConf
 
 
 export const DataSource = ({ connection, token, status }: { connection: ConnectionQuery, token: string | undefined | null, status: "PROCESSING" | "FINISHED" | undefined }) => {
- 
   switch (connection.service) {
     case "GOOGLE_DRIVE":
       return <>
         {connection.isConfigSet && <SyncConnection connection={connection} status={status} />}
         <ConfigGoogleDrive connection={connection} token={token} status={status} />
-        <DeleteConnection connection={connection} status={status}/>
+        <DeleteConnection connection={connection} status={status} />
       </>
     case "DIRECT_UPLOAD":
       return <>

--- a/actions/connctions/sync/index.ts
+++ b/actions/connctions/sync/index.ts
@@ -11,7 +11,7 @@ import { z } from "zod"
 
 const syncConnectionSchema = z.object({
   id: z.string().min(2),
-  pageLimit: z.string().nullable().transform((str, ctx): number | null => {
+  pageLimit: z.string().transform((str, ctx): number | null => {
     try {
       if (str) return parseInt(str)
       return null
@@ -19,8 +19,8 @@ const syncConnectionSchema = z.object({
       ctx.addIssue({ code: 'invalid_date', message: "invalid page limit" })
       return z.NEVER
     }
-  }),
-  documentLimit: z.string().nullable().transform((str, ctx): number | null => {
+  }).nullable(),
+  fileLimitd: z.string().nullable().transform((str, ctx): number | null => {
     try {
       if (str) return parseInt(str)
       return null
@@ -28,7 +28,7 @@ const syncConnectionSchema = z.object({
       ctx.addIssue({ code: 'invalid_date', message: "invalid page limit" })
       return z.NEVER
     }
-  }),
+  }).nullable(),
 })
 
 type FormState = {
@@ -40,10 +40,10 @@ export const syncConnectionConfig = async (_: FormState, formData: FormData) => 
 
   try {
     if (!session?.user?.email) throw new Error("forbidden");
-    const { id, pageLimit, documentLimit } = syncConnectionSchema.parse({
+    const { id, pageLimit, fileLimitd } = syncConnectionSchema.parse({
       id: formData.get("id"),
       pageLimit: formData.get("pageLimit"),
-      fileLimit: formData.get("fileLimit")
+      fileLimitd: formData.get("fileLimit")
     })
 
     const conn = await databaseDrizzle.update(connections).set({
@@ -59,7 +59,7 @@ export const syncConnectionConfig = async (_: FormState, formData: FormData) => 
       service: conn[0].service,
       metadata: conn[0].metadata || null,
       pageLimit: pageLimit,
-      fileLimit: documentLimit,
+      fileLimit: fileLimitd,
       files: [],
       links: []
     })

--- a/app/api/connections/[id]/status/route.ts
+++ b/app/api/connections/[id]/status/route.ts
@@ -1,0 +1,66 @@
+import { databaseDrizzle } from "@/db"
+import { checkAuth } from "@/lib/api_key"
+import { tryAndCatch } from "@/lib/try-catch"
+import { NextRequest, NextResponse } from "next/server"
+import { APIError } from "openai"
+
+
+type Params = {
+  params: Promise<{
+    id: string
+  }>
+}
+
+export async function GET(request: NextRequest, { params }: Params) {
+  try {
+    const {
+      data: userId,
+      error: authError,
+    } = await tryAndCatch<string, APIError>(checkAuth(request))
+    if (authError) {
+      return NextResponse.json({
+        code: authError.code,
+        message: authError.message,
+      }, { status: authError.status })
+    }
+
+    const { id } = await params
+    const { data: conn, error: queryError } = await tryAndCatch(databaseDrizzle.query.connections.findFirst({
+      where: (conn, ops) => ops.and(ops.eq(conn.userId, userId!), ops.eq(conn.id, id)),
+      columns: {
+        isConfigSet: true,
+        isSyncing: true,
+      },
+    }))
+    if (queryError) {
+      return NextResponse.json(
+        {
+          code: "internal_server_error",
+          message: "Failed to load connection status",
+        },
+        { status: 500 },
+      )
+    }
+    if (!conn) {
+      return NextResponse.json(
+        {
+          code: "not_found",
+          message: "Connection Not Found",
+        },
+        { status: 404 },
+      )
+    }
+
+    const response = {
+      status: conn.isConfigSet ? 'ready' : 'config_missing',
+      isSyncing: conn.isSyncing
+    }
+
+    return NextResponse.json(response, { status: 200 });
+  } catch (error: any) {
+    return NextResponse.json(
+      { code: "internal_server_error", message: error.message },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/connections/[id]/sync/route.ts
+++ b/app/api/connections/[id]/sync/route.ts
@@ -1,0 +1,130 @@
+import { databaseDrizzle } from "@/db"
+import { connectionProcessFiles } from "@/fileProcessors"
+import { checkAuth } from "@/lib/api_key"
+import { tryAndCatch } from "@/lib/try-catch"
+import { addToProcessFilesQueue } from "@/workers/queues/jobs/processFiles.job"
+import { NextRequest, NextResponse } from "next/server"
+import { APIError } from "openai"
+
+
+type Params = {
+  params: Promise<{
+    id: string
+  }>
+}
+
+export async function POST(request: NextRequest, { params }: Params) {
+  const wait = request.nextUrl.searchParams.get("wait")
+
+  try {
+    const {
+      data: userId,
+      error: authError,
+    } = await tryAndCatch<string, APIError>(checkAuth(request))
+    if (authError) {
+      return NextResponse.json({
+        code: authError.code,
+        message: authError.message,
+      }, { status: authError.status })
+    }
+
+    const { id } = await params
+    const { data: conn, error: queryError } = await tryAndCatch(databaseDrizzle.query.connections.findFirst({
+      where: (conn, ops) => ops.and(ops.eq(conn.userId, userId!), ops.eq(conn.id, id)),
+      columns: {
+        id: true,
+        service: true,
+        isConfigSet: true,
+        isSyncing: true,
+        metadata: true
+      },
+      with: {
+        files: {
+          columns: {
+            totalPages: true,
+
+          }
+        },
+      }
+    }))
+    if (queryError) {
+      return NextResponse.json(
+        {
+          code: "internal_server_error",
+          message: "Failed to load connection status",
+        },
+        { status: 500 },
+      )
+    }
+    if (!conn) {
+      return NextResponse.json(
+        {
+          code: "not_found",
+          message: "Connection Not Found",
+        },
+        { status: 404 },
+      )
+    }
+    if (!conn.isConfigSet) {
+      return NextResponse.json(
+        {
+          code: 'config_missing',
+          message:
+            'This connection is not fully configured',
+        },
+        { status: 400 },
+      )
+    }
+    if (conn.isSyncing) {
+      return NextResponse.json(
+        {
+          code: 'already_syncing',
+          message:
+            'A sync operation is already in progress for this connection',
+        },
+        { status: 400 },
+      )
+    }
+
+    const filesConfig = {
+      connectionId: conn.id,
+      service: conn.service,
+      pageLimit: conn.files.reduce((sum, f) => f.totalPages + sum, 0),
+      fileLimit: conn.files.length,
+      metadata: conn.metadata || null,
+      links: [],
+      files: []
+
+    }
+
+    if (wait === "true") {
+      const { error } = await tryAndCatch(connectionProcessFiles(filesConfig))
+      if (error) return NextResponse.json({
+        code: "internal_server_error",
+        message: error.message
+      }, { status: 500 });
+
+      return NextResponse.json({
+        code: "ok",
+        message: "Your file was successfully synced and processed",
+      }, { status: 200 })
+    }
+
+    const { error: errorQueue } = await tryAndCatch(addToProcessFilesQueue(filesConfig))
+    if (errorQueue) return NextResponse.json({
+      code: "internal_server_error",
+      message: errorQueue.message,
+    }, { status: 500 })
+
+    return NextResponse.json({
+      code: "ok",
+      message: "Your file has been successfully queued for syncing",
+    }, { status: 200 })
+
+  } catch (error: any) {
+    return NextResponse.json(
+      { code: "internal_server_error", message: error.message },
+      { status: 500 },
+    );
+  }
+}

--- a/components/DeleteConnection/DeleteConnection.tsx
+++ b/components/DeleteConnection/DeleteConnection.tsx
@@ -50,7 +50,7 @@ export const DeleteConnection = ({ connection, status }: { connection: Connectio
     <Dialog open={open} onOpenChange={e => setOpen(e)} >
       <DialogTrigger asChild>
         <DialogTrigger asChild>
-          <Button size='sm' variant={'ghost'} disabled={status === 'PROCESSING' && connection.isSyncing}>
+          <Button size='sm' variant={'ghost'} disabled={status === 'PROCESSING' || (!status && connection.isSyncing)}>
             <Trash />
             Delete
           </Button>

--- a/components/SyncConnection/SyncConnection.tsx
+++ b/components/SyncConnection/SyncConnection.tsx
@@ -52,7 +52,7 @@ export const SyncConnection = ({ connection, status }: {
   return (<Dialog open={open} onOpenChange={e => setOpen(e)} >
     <DialogTrigger asChild>
       <DialogTrigger asChild>
-        <Button size='sm' variant={'ghost'} disabled={status === 'PROCESSING' && connection.isSyncing}>
+        <Button size='sm' variant={'ghost'} disabled={status === 'PROCESSING' ||(!status && connection.isSyncing)}>
           <FolderSync />
           Sync
         </Button>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Part: #29  <!-- reference the related issue e.g. #150 -->

### Description:
This PR introduces 
- New POST endpoint at `/api/connection/{id}/sync` to enable users to sync connection, supporting both immediate and queued processing workflows.
- New GET endpoint at `/api/connection/{id}/status` to enable users to get status of the connection is it ready ? syncing ? 
- fix bug frontend 


- If `wait=true` (query parameter), : processes files immediately with `connectionProcessFiles` and returns a success message
- If `wait=false` **(default)**, : queues files for later processing with addToProcessFilesQueue and returns

```json
{
      "code": "ok",
      "message": "Your file has been successfully queued for syncing"
}
```
