### PR TITLE
PUT: update connection details and allow for adding new files to conn…

### DIFF
--- a/DataSource/GoogleDrive/ConfigGoogleDrive/ConfigGoogleDrive.tsx
+++ b/DataSource/GoogleDrive/ConfigGoogleDrive/ConfigGoogleDrive.tsx
@@ -33,7 +33,7 @@ export const ConfigGoogleDrive = ({ connection, token, status }: { connection: C
   });
 
   const handleSetConfig = (data: FormData) => {
-    data.set("id", connection.id)
+    data.set("connectionId", connection.id)
     data.set("folderName", directory.name)
     data.set("service", connection.service)
     directory?.id && data.set("folderId", directory.id)

--- a/actions/connctions/delete/index.ts
+++ b/actions/connctions/delete/index.ts
@@ -22,7 +22,7 @@ export async function deleteConnectionConfig(_: FormState, formData: FormData) {
   try {
     if (!session?.user?.id) throw new Error("forbidden");
     const { id } = deleteConnectionSchema.parse({
-      id: formData.get("id"),
+      id: formData.get("connectionId"),
     })
 
     const connectionChunksIds = await databaseDrizzle

--- a/actions/connctions/sync/index.ts
+++ b/actions/connctions/sync/index.ts
@@ -10,7 +10,7 @@ import { revalidatePath } from "next/cache";
 import { z } from "zod"
 
 const syncConnectionSchema = z.object({
-  id: z.string().min(2),
+  connectionId: z.string().min(2),
   pageLimit: z.string().transform((str, ctx): number | null => {
     try {
       if (str) return parseInt(str)
@@ -40,22 +40,22 @@ export const syncConnectionConfig = async (_: FormState, formData: FormData) => 
 
   try {
     if (!session?.user?.email) throw new Error("forbidden");
-    const { id, pageLimit, fileLimitd } = syncConnectionSchema.parse({
-      id: formData.get("id"),
+    const { connectionId, pageLimit, fileLimitd } = syncConnectionSchema.parse({
+      connectionId: formData.get("connectionId"),
       pageLimit: formData.get("pageLimit"),
       fileLimitd: formData.get("fileLimit")
     })
 
     const conn = await databaseDrizzle.update(connections).set({
       isSyncing: true,
-    }).where(eq(connections.id, id))
+    }).where(eq(connections.id, connectionId))
       .returning({
         metadata: connections.metadata,
         service: connections.service,
       })
 
     await addToProcessFilesQueue({
-      connectionId: id,
+      connectionId: connectionId,
       service: conn[0].service,
       metadata: conn[0].metadata || null,
       pageLimit: pageLimit,

--- a/app/api/connections/[id]/route.ts
+++ b/app/api/connections/[id]/route.ts
@@ -94,7 +94,6 @@ export async function GET(request: NextRequest, { params }: Params) {
       files: conn.files,
     }
 
-
     return NextResponse.json(response, { status: 200 });
   } catch (error: any) {
     return NextResponse.json(

--- a/app/api/connections/[id]/update/route.ts
+++ b/app/api/connections/[id]/update/route.ts
@@ -1,0 +1,134 @@
+import { connectionProcessFiles, directProcessFiles } from "@/fileProcessors";
+import { checkAuth } from "@/lib/api_key";
+import { tryAndCatch } from "@/lib/try-catch";
+import { addToProcessFilesQueue } from "@/workers/queues/jobs/processFiles.job";
+import { NextRequest, NextResponse } from "next/server";
+import { APIError } from "@/lib/APIError";
+import { databaseDrizzle } from "@/db";
+import { setConnectionToProcess } from "@/fileProcessors/connectors";
+
+type Params = {
+  params: Promise<{
+    id: string
+  }>
+}
+
+export async function POST(request: NextRequest, { params }: Params) {
+  const wait = request.nextUrl.searchParams.get("wait")
+
+  try {
+    const {
+      data: userId,
+      error: authError,
+    } = await tryAndCatch<string, APIError>(checkAuth(request))
+
+    if (authError) return NextResponse.json({
+      code: authError.code,
+      message: authError.message,
+    }, { status: authError.status })
+
+    const { id } = await params;
+    const { data: conn, error: queryError } = await tryAndCatch(databaseDrizzle.query.connections.findFirst({
+      where: (conn, ops) => ops.and(ops.eq(conn.id, id), ops.eq(conn.userId, userId)),
+      columns: {
+        isSyncing: true,
+        service: true,
+        folderName: true,
+      }
+    }))
+    if (queryError) {
+      return NextResponse.json(
+        {
+          code: "internal_server_error",
+          message: "Failed to load connection",
+        },
+        { status: 500 },
+      )
+    }
+
+    if (!conn) {
+      return NextResponse.json(
+        {
+          code: "not_found",
+          message: "Connection Not Found",
+        },
+        { status: 404 },
+      )
+    }
+
+    if (conn.isSyncing) {
+      return NextResponse.json(
+        {
+          code: 'already_syncing',
+          message:
+            'A sync operation is already in progress for this connection',
+        },
+        { status: 400 },
+      )
+    }
+
+    const { data: formData, error: errorForm } = await tryAndCatch(request.formData());
+    if (errorForm) return NextResponse.json({
+      code: "bad_request",
+      message: errorForm.message,
+    }, { status: 400 })
+
+    formData.set("userId", userId)
+    formData.set("connectionId", id)
+    formData.set("folderName", conn.folderName || "*")
+
+    if (conn.service === 'DIRECT_UPLOAD') {
+      formData.set("service", "DIRECT_UPLOAD_UPDATE")
+    } else {
+      formData.set("service", conn.service)
+    }
+
+    const {
+      data: filesConfig,
+      error: errorConfig
+    } = await tryAndCatch(setConnectionToProcess(formData))
+
+    if (errorConfig) return NextResponse.json({
+      code: "bad_request",
+      message: errorConfig.message,
+    }, { status: 400 })
+
+    if (wait === "true") {
+      const links = formData.getAll("links") || []
+      const files = formData.getAll("files") || []
+
+      if (links.length > 0 || files.length > 0) {
+        var { error } = await tryAndCatch(directProcessFiles(filesConfig))
+      } else {
+        var { error } = await tryAndCatch(connectionProcessFiles(filesConfig))
+      }
+
+      if (error) return NextResponse.json({
+        code: "internal_server_error",
+        message: error.message
+      }, { status: 500 });
+
+      return NextResponse.json({
+        code: "ok",
+        message: "Connection successfully updated",
+      }, { status: 200 })
+    }
+
+    const { error: errorQueue } = await tryAndCatch(addToProcessFilesQueue(filesConfig))
+    if (errorQueue) return NextResponse.json({
+      code: "internal_server_error",
+      message: errorQueue.message,
+    }, { status: 500 })
+
+    return NextResponse.json({
+      code: "ok",
+      message: "Connection has been successfully updated and queued for processing.",
+    }, { status: 200 })
+
+  } catch (error: any) {
+    return NextResponse.json({
+      code: "internal_server_error",
+      message: error.message,
+    }, { status: 500 });
+  }
+}

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -4,7 +4,7 @@ import { checkAuth } from "@/lib/api_key";
 import { tryAndCatch } from "@/lib/try-catch";
 import { addToProcessFilesQueue } from "@/workers/queues/jobs/processFiles.job";
 import { NextRequest, NextResponse } from "next/server";
-import { APIError } from "openai";
+import { APIError } from "@/lib/APIError";
 
 export async function POST(request: NextRequest) {
   const wait = request.nextUrl.searchParams.get("wait")

--- a/components/DeleteConnection/DeleteConnection.tsx
+++ b/components/DeleteConnection/DeleteConnection.tsx
@@ -25,7 +25,7 @@ export const DeleteConnection = ({ connection, status }: { connection: Connectio
     startTransition(async () => {
       try {
         const formData = new FormData();
-        formData.set("id", connection.id)
+        formData.set("connectionId", connection.id)
         formData.set("service", connection.service)
         formData.set("metadata", JSON.stringify(connection.connectionMetadata))
         const res = await deleteConnectionConfig(EMPTY_FORM_STATE, formData)

--- a/components/SyncConnection/SyncConnection.tsx
+++ b/components/SyncConnection/SyncConnection.tsx
@@ -27,7 +27,7 @@ export const SyncConnection = ({ connection, status }: {
     startTransition(async () => {
       try {
         const formData = new FormData();
-        formData.set("id", connection.id)
+        formData.set("connectionId", connection.id)
         formData.set("pageLimit", connection.files.reduce((s, f) => s + f.totalPages, 0).toString())
         formData.set("fileLimit", connection.files.length.toString())
         const res = await syncConnectionConfig(EMPTY_FORM_STATE, formData)

--- a/fileProcessors/connectors/index.ts
+++ b/fileProcessors/connectors/index.ts
@@ -5,7 +5,6 @@ import { TQueue } from "@/workers/queues/jobs/processFiles.job";
 import { setGoogleDriveConnection } from "@/DataSource/GoogleDrive/setGoogleDriveConnection";
 import { setDirectUploadConnection, updateDirectUploadConnection } from "@/DataSource/DirectUpload/setDirectUploadConnection";
 
-
 export const getConnectionToken = async (connection: ConnectionTable) => {
   switch (connection.service) {
     case "GOOGLE_DRIVE":


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

part: #29  <!-- reference the related issue e.g. #150 -->

### Description:
This PR introduces a new POST endpoint at `/api/connection/{id}/update` to enable users to update connections, supporting both immediate and queued processing workflows.

- If `wait=true` (query parameter), : processes files immediately with directProcessFiles and returns a success message: **"Your file was successfully uploaded and processed."**
- If `wait=false` **(default)**, : queues files for later processing with addToProcessFilesQueue and returns: **"Your file has been successfully uploaded and queued for processing."**
- and fix typo 
```json
{
    "code": "ok",
    "message": "Connection has been successfully updated and queued for processing"
}
```

<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
