### PR TITLE
Dropbox OAuth auto-connects to previously authorized account without prompting for new login

### DIFF
--- a/fileProcessors/connectors/dropbox.ts
+++ b/fileProcessors/connectors/dropbox.ts
@@ -23,7 +23,7 @@ export const authDropbox = async () => {
     'code',
     'offline',
     ["files.metadata.read", "files.content.read", "email", "openid", "account_info.read"]
-  )
+  ).then(authUrl => `${authUrl}&force_reapprove=true`);
   return authUrl.toString();
 }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

part: #77 

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
Connect a new Dropbox account, Dropbox will force a fresh sign-in/approval flow, letting them pick or sign into whichever account they want.
<!-- Even better add a screenshot / gif / loom -->
