### PR TITLE
remove google drive from cloud

### DIFF
--- a/components/Connectors/Connectors.tsx
+++ b/components/Connectors/Connectors.tsx
@@ -3,14 +3,18 @@ import { FaGoogleDrive, FaDropbox } from "react-icons/fa";
 import { ConnectionBtn } from './ConnectionBtn';
 import { SiAwslambda } from 'react-icons/si';
 
+const isCloud = process.env.DCUP_ENV === 'CLOUD';
+
 export const Connectors = async () => {
   const connectors = [
-    {
-      id: 'google-drive',
-      name: 'Google Drive',
-      icon: <FaGoogleDrive className="w-6 h-6" />,
-      description: 'Connect your Google Drive to access documents and files',
-    },
+    ...(!isCloud ? [
+      {
+        id: 'google-drive',
+        name: 'Google Drive',
+        icon: <FaGoogleDrive className="w-6 h-6" />,
+        description: 'Connect your Google Drive to access documents and files',
+      },
+    ] : []),
     {
       id: "dropbox",
       name: "Dropbox",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:#96 <!-- reference the related issue e.g. #150 -->

### Description:
google drive did not allow to use the google drive.readonly api which is what we depends on in the app for syncing and other functionality
remove it from the cloud verstion but we will keep it in the OS one
